### PR TITLE
Update test harness for pure11

### DIFF
--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -12,97 +12,125 @@
 --
 -----------------------------------------------------------------------------
 
-{-# LANGUAGE DataKinds, DoAndIfThenElse #-}
+{-# LANGUAGE DataKinds, DoAndIfThenElse, GeneralizedNewtypeDeriving, TupleSections #-}
 
 module Main (main) where
 
 import qualified Language.PureScript as P
 
 import Data.List (isSuffixOf)
-import Data.Traversable (traverse)
+import Data.Traversable (for, traverse)
 import Control.Monad
+import Control.Monad.IO.Class
+import Control.Monad.Trans (lift)
 import Control.Monad.Trans.Maybe (MaybeT(..), runMaybeT)
-import Control.Monad.Reader (runReaderT)
+import Control.Monad.Reader (MonadReader, ReaderT, runReaderT)
+import Control.Monad.Except (ExceptT(..), MonadError, runExceptT)
 import Control.Applicative
+import Control.Arrow (first)
 import System.Exit
 import System.Process
-import System.FilePath (pathSeparator)
-import System.Directory (getCurrentDirectory, getTemporaryDirectory, getDirectoryContents, findExecutable)
-import Text.Parsec (ParseError)
+import System.FilePath ((</>), pathSeparator, takeDirectory)
+import System.Directory (createDirectoryIfMissing, doesFileExist, findExecutable,
+                         getCurrentDirectory, getDirectoryContents, getModificationTime,
+                         getTemporaryDirectory, setCurrentDirectory)
+import System.IO.Error (tryIOError)
+
+newtype Make a = Make { unMake :: ReaderT (P.Options P.Make) (ExceptT String IO) a }
+  deriving (Functor, Applicative, Monad, MonadIO, MonadError String, MonadReader (P.Options P.Make))
+
+runMake :: P.Options P.Make -> Make a -> IO (Either String a)
+runMake opts = runExceptT . flip runReaderT opts . unMake
+
+makeIO :: IO a -> Make a
+makeIO = Make . lift . ExceptT . fmap (either (Left . show) Right) . tryIOError
+
+instance P.MonadMake Make where
+  getTimestamp path = makeIO $ do
+    exists <- doesFileExist path
+    traverse (const $ getModificationTime path) $ guard exists
+  readTextFile path = makeIO $ do
+    putStrLn $ "Reading " ++ path
+    readFile path
+  writeTextFile path text = makeIO $ do
+    createDirectoryIfMissing True $ takeDirectory path
+    putStrLn $ "Writing " ++ path
+    writeFile path text
+  progress = makeIO . putStrLn
 
 readInput :: [FilePath] -> IO [(FilePath, String)]
 readInput inputFiles = forM inputFiles $ \inputFile -> do
   text <- readFile inputFile
   return (inputFile, text)
 
-loadPrelude :: Either String (String, String, P.Environment)
-loadPrelude =
-  case P.parseModulesFromFiles id [("", P.prelude)] of
-    Left parseError -> Left (show parseError)
-    Right ms -> runReaderT (P.compile (map snd ms) []) $ P.defaultCompileOptions { P.optionsAdditional = P.CompileOptions "Tests" [] [] }
-
-compile :: P.Options P.Compile -> [FilePath] -> IO (Either String (String, String, P.Environment))
+compile :: P.Options P.Make -> [FilePath] -> IO (Either String (FilePath, P.Environment))
 compile opts inputFiles = do
-  modules <- P.parseModulesFromFiles id <$> readInput inputFiles
+  modules <- P.parseModulesFromFiles id . ((P.prelude, P.prelude) :) <$> readInput inputFiles
+  let outputDir = "test-output"
   case modules of
     Left parseError ->
       return (Left $ show parseError)
-    Right ms -> return $ runReaderT (P.compile (map snd ms) []) opts
+    Right ms -> fmap (fmap (outputDir, )) $ runMake opts $ P.make outputDir (map (first Right) ms) []
 
-assert :: FilePath -> P.Options P.Compile -> FilePath -> (Either String (String, String, P.Environment) -> IO (Maybe String)) -> IO ()
-assert preludeExterns opts inputFile f = do
-  e <- compile opts [preludeExterns, inputFile]
+assert :: P.Options P.Make -> FilePath -> (Either String (FilePath, P.Environment) -> IO (Maybe String)) -> IO ()
+assert opts inputFile f = do
+  e <- compile opts [inputFile]
   maybeErr <- f e
   case maybeErr of
     Just err -> putStrLn err >> exitFailure
     Nothing -> return ()
 
-assertCompiles :: String -> FilePath -> FilePath -> IO ()
-assertCompiles preludeJs preludeExterns inputFile = do
+assertCompiles :: FilePath -> IO ()
+assertCompiles inputFile = do
   putStrLn $ "Assert " ++ inputFile ++ " compiles successfully"
-  let options = P.defaultCompileOptions
-                              { P.optionsMain = Just "Main"
-                              , P.optionsAdditional = P.CompileOptions "Tests" ["Main"] ["Main"]
-                              }
-  assert preludeExterns options inputFile $ either (return . Just) $ \(js, _, _) -> do
-    process <- findNodeProcess
-    result <- traverse (\node -> readProcessWithExitCode node [] (preludeJs ++ js)) process
+  let options = P.defaultMakeOptions
+  assert options inputFile $ either (return . Just) $ \(outputDir, _) -> do
+    mexes <- runMaybeT $ (,) <$> findOneExecutableIn ["cmake"] <*> findOneExecutableIn ["make"]
+
+    let buildDir = outputDir </> "build"
+    origCwd <- getCurrentDirectory
+    print (origCwd, outputDir, buildDir)
+    createDirectoryIfMissing True buildDir
+    setCurrentDirectory buildDir
+
+    let handleExitStatus s cont = case s of
+          (ExitFailure _, _, err) -> return $ Just err
+          (ExitSuccess, out, _) -> putStrLn out >> cont
+
+    result <- for mexes $ \(cmake, make) -> do
+      cmakeResult <- readProcessWithExitCode cmake [".."] ""
+      handleExitStatus cmakeResult $ do
+        makeResult <- readProcessWithExitCode make [] ""
+        handleExitStatus makeResult (return Nothing)
+
+    setCurrentDirectory origCwd
+
     case result of
-      Just (ExitSuccess, out, _) -> putStrLn out >> return Nothing
-      Just (ExitFailure _, _, err) -> return $ Just err
+      Just merr -> return merr
       Nothing -> return $ Just "Couldn't find node.js executable"
 
-assertDoesNotCompile :: FilePath -> FilePath -> IO ()
-assertDoesNotCompile preludeExterns inputFile = do
+assertDoesNotCompile :: FilePath -> IO ()
+assertDoesNotCompile inputFile = do
   putStrLn $ "Assert " ++ inputFile ++ " does not compile"
-  assert preludeExterns (P.defaultCompileOptions { P.optionsAdditional = P.CompileOptions "Tests" [] [] }) inputFile $ \e ->
+  assert P.defaultMakeOptions inputFile $ \e ->
     case e of
       Left err -> putStrLn err >> return Nothing
       Right _ -> return $ Just "Should not have compiled"
 
-findNodeProcess :: IO (Maybe String)
-findNodeProcess = runMaybeT . msum $ map (MaybeT . findExecutable) names
-    where names = ["nodejs", "node"]
+findOneExecutableIn :: [String] -> MaybeT IO String
+findOneExecutableIn = msum . map (MaybeT . findExecutable)
 
 main :: IO ()
 main = do
-  putStrLn "Compiling Prelude"
-  case loadPrelude of
-    Left err -> putStrLn err >> exitFailure
-    Right (preludeJs, exts, _) -> do
-      tmp <- getTemporaryDirectory
-      let preludeExterns = tmp ++ pathSeparator : "prelude.externs"
-      writeFile preludeExterns exts
-      putStrLn $ "Wrote " ++ preludeExterns
-      cd <- getCurrentDirectory
-      let examples = cd ++ pathSeparator : "examples"
-      let passing = examples ++ pathSeparator : "passing"
-      passingTestCases <- getDirectoryContents passing
-      forM_ passingTestCases $ \inputFile -> when (".purs" `isSuffixOf` inputFile) $
-        assertCompiles preludeJs preludeExterns (passing ++ pathSeparator : inputFile)
-      let failing = examples ++ pathSeparator : "failing"
-      failingTestCases <- getDirectoryContents failing
-      forM_ failingTestCases $ \inputFile -> when (".purs" `isSuffixOf` inputFile) $
-        assertDoesNotCompile preludeExterns (failing ++ pathSeparator : inputFile)
-      exitSuccess
+  cd <- getCurrentDirectory
+  let examples = cd ++ pathSeparator : "examples"
+  let passing = examples ++ pathSeparator : "passing"
+  passingTestCases <- getDirectoryContents passing
+  forM_ passingTestCases $ \inputFile -> when (".purs" `isSuffixOf` inputFile) $
+    assertCompiles (passing ++ pathSeparator : inputFile)
+  let failing = examples ++ pathSeparator : "failing"
+  failingTestCases <- getDirectoryContents failing
+  forM_ failingTestCases $ \inputFile -> when (".purs" `isSuffixOf` inputFile) $
+    assertDoesNotCompile (failing ++ pathSeparator : inputFile)
+  exitSuccess
 


### PR DESCRIPTION
Just a quick patch to get the test harness working again. Tests are built using `Language.PureScript.make` instead of `compile` now, since that's what `pcc` uses. The `MonadMake` bits were copied from `psc-make/Main.hs`.
