### PR TITLE
adding support for building using nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ cabal.sandbox.config
 .test_modules/
 bower_components/
 node_modules
+pscpp.cabal
 tmp/
 .stack-work/
 output

--- a/stack.nix
+++ b/stack.nix
@@ -1,0 +1,8 @@
+{ pkgs ? import <nixpkgs> {}, ghc ? pkgs.ghc }:
+
+pkgs.haskell.lib.buildStackProject {
+  name = "default-stack-shell";
+  inherit ghc;
+  buildInputs = with pkgs; [git git-lfs gmp zlib];
+  LANG = "en_US.UTF-8";
+}

--- a/stack.yaml
+++ b/stack.yaml
@@ -67,3 +67,7 @@ extra-deps:
 #
 # Allow a newer minor version of GHC than the snapshot specifies
 # compiler-check: newer-minor
+
+nix:
+  shell-file: stack.nix
+


### PR DESCRIPTION
This just adds support for using the project with stack on nix, using `stack --nix` commands. Note that no nix expression is provided for setting up an environment to develop using purescript-native, yet.