### PR TITLE
Read and write all files as UTF8 (fixes #26)

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -23,6 +23,7 @@ description:         Please see the README on Github at <https://github.com/andy
 
 dependencies:
 - base >= 4.7 && < 5
+- bytestring >= 0.10.8.2 && < 0.11
 - purescript -any
 - base-compat >=0.6.0
 - protolude >=0.1.6


### PR DESCRIPTION
Hi, first of all I'm a Haskell newb, so apologies if there's anything wrong here or if I've overlooked anything. 

This replaces the use of `readFile` and `writeFile` from `System.Text.IO`, with those functions in `Data.ByteString`, to make sure the runtime files are written exactly as-is, rather than using the faulty System.Text.IO.readFile/writeFile behavior.

Reference: https://www.snoyman.com/blog/2016/12/beware-of-readfile

I'm not sure of all the drawbacks to using ByteString, but we're not dealing with huge files here and it seems to be ok. It's fixed the problem on my Windows machine.

Thanks for all you hard work on this project!