### PR TITLE
Enable Nix in stack.yaml

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -13,6 +13,7 @@ extra-deps:
 - semialign-1
 
 nix:
+  enable: true
   shell-file: stack.nix
 
 flags:


### PR DESCRIPTION
Fixes https://github.com/andyarvanitis/purescript-native/issues/68.

For others wanting to use `psgo` from their nix projects or NixOS, this worked for me:

```nix
  psgo = pkgs.haskell.lib.buildStackProject {
    name = "psgo";
    src = pkgs.fetchFromGitHub {
      owner = "iclanzan";
      repo = "purescript-native";
      rev = "4ce2c9f363cdebf4b237b74b826c28099cabc075";
      sha256 = "0dwi89dgyzy1sn33sf9fk5xm229rfaxahndv45h7vg6zqcw6smyl";
    };
    ghc = pkgs.haskell.compiler.ghc865;
    buildInputs = with pkgs; [ git git-lfs gmp ncurses zlib ];
    LANG = "en_US.UTF-8";
  }
```

> Note that Nixpkgs ships with a convenience wrapper function around `mkDerivation` called `haskell.lib.buildStackProject` to help you create this derivation in exactly the way Stack expects. However for this to work you need to disable the sandbox, which you can do by using `--option sandbox relaxed` or `--option sandbox false` to the Nix command.
- https://haskell4nix.readthedocs.io/nixpkgs-users-guide.html