### PR TITLE
Add Nix flake support

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ core-tests/full-core-docs.md
 .psc-ide-port
 .vscode/
 result
+
+/.direnv/
+
+!.gitignore

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,345 @@
+{
+  "nodes": {
+    "HTTP": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1451647621,
+        "narHash": "sha256-oHIyw3x0iKBexEo49YeUDV1k74ZtyYKGR2gNJXXRxts=",
+        "owner": "phadej",
+        "repo": "HTTP",
+        "rev": "9bc0996d412fef1787449d841277ef663ad9a915",
+        "type": "github"
+      },
+      "original": {
+        "owner": "phadej",
+        "repo": "HTTP",
+        "type": "github"
+      }
+    },
+    "cabal-32": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1603716527,
+        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.2",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-34": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1640353650,
+        "narHash": "sha256-N1t6M3/wqj90AEdRkeC8i923gQYUpzSr8b40qVOZ1Rk=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "942639c18c0cd8ec53e0a6f8d120091af35312cd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.4",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-36": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1641652457,
+        "narHash": "sha256-BlFPKP4C4HRUJeAbdembX1Rms1LD380q9s0qVDeoAak=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "f27667f8ec360c475027dcaee0138c937477b070",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.6",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cardano-shell": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1608537748,
+        "narHash": "sha256-PulY1GfiMgKVnBci3ex4ptk2UNYMXqGjJOxcPy2KYT4=",
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "rev": "9392c75087cb9a3d453998f4230930dea3a95725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1641205782,
+        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "ghc-8.6.5-iohk": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1600920045,
+        "narHash": "sha256-DO6kxJz248djebZLpSzTGD6s8WRpNI9BTwUeOf5RwY8=",
+        "owner": "input-output-hk",
+        "repo": "ghc",
+        "rev": "95713a6ecce4551240da7c96b6176f980af75cae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "release/8.6.5-iohk",
+        "repo": "ghc",
+        "type": "github"
+      }
+    },
+    "hackage": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1646625282,
+        "narHash": "sha256-U23F/EXZC1UOxO3SkfzS82TwYtT42sp5Y6BImXsHWMo=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "bff4ab542bc6f68fc078ccd0df2e8eae61650e32",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "haskellNix": {
+      "inputs": {
+        "HTTP": "HTTP",
+        "cabal-32": "cabal-32",
+        "cabal-34": "cabal-34",
+        "cabal-36": "cabal-36",
+        "cardano-shell": "cardano-shell",
+        "flake-utils": "flake-utils_2",
+        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
+        "hackage": "hackage",
+        "hpc-coveralls": "hpc-coveralls",
+        "nix-tools": "nix-tools",
+        "nixpkgs": [
+          "haskellNix",
+          "nixpkgs-unstable"
+        ],
+        "nixpkgs-2003": "nixpkgs-2003",
+        "nixpkgs-2105": "nixpkgs-2105",
+        "nixpkgs-2111": "nixpkgs-2111",
+        "nixpkgs-unstable": "nixpkgs-unstable",
+        "old-ghc-nix": "old-ghc-nix",
+        "stackage": "stackage"
+      },
+      "locked": {
+        "lastModified": 1646638312,
+        "narHash": "sha256-lJ++HRaVuHmbGmyo4dXXbtomXK+v33Q0HCHB1PWa0CY=",
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "rev": "b1113d486ffcd65d6527732f9ed5270e58dc4e49",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "type": "github"
+      }
+    },
+    "hpc-coveralls": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1607498076,
+        "narHash": "sha256-8uqsEtivphgZWYeUo5RDUhp6bO9j2vaaProQxHBltQk=",
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "rev": "14df0f7d229f4cd2e79f8eabb1a740097fdfa430",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "type": "github"
+      }
+    },
+    "nix-tools": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1644395812,
+        "narHash": "sha256-BVFk/BEsTLq5MMZvdy3ZYHKfaS3dHrsKh4+tb5t5b58=",
+        "owner": "input-output-hk",
+        "repo": "nix-tools",
+        "rev": "d847c63b99bbec78bf83be2a61dc9f09b8a9ccc1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "nix-tools",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2003": {
+      "locked": {
+        "lastModified": 1620055814,
+        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-20.03-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2105": {
+      "locked": {
+        "lastModified": 1642244250,
+        "narHash": "sha256-vWpUEqQdVP4srj+/YLJRTN9vjpTs4je0cdWKXPbDItc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0fd9ee1aa36ce865ad273f4f07fdc093adeb5c00",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2111": {
+      "locked": {
+        "lastModified": 1644510859,
+        "narHash": "sha256-xjpVvL5ecbyi0vxtVl/Fh9bwGlMbw3S06zE5nUzFB8A=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0d1d5d7e3679fec9d07f2eb804d9f9fdb98378d3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1644486793,
+        "narHash": "sha256-EeijR4guVHgVv+JpOX3cQO+1XdrkJfGmiJ9XVsVU530=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1882c6b7368fd284ad01b0a5b5601ef136321292",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "old-ghc-nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1631092763,
+        "narHash": "sha256-sIKgO+z7tj4lw3u6oBZxqIhDrzSkvpHtv0Kki+lh9Fg=",
+        "owner": "angerman",
+        "repo": "old-ghc-nix",
+        "rev": "af48a7a7353e418119b6dfe3cd1463a657f342b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "angerman",
+        "ref": "master",
+        "repo": "old-ghc-nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "haskellNix": "haskellNix",
+        "nixpkgs": [
+          "haskellNix",
+          "nixpkgs-unstable"
+        ]
+      }
+    },
+    "stackage": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1646625386,
+        "narHash": "sha256-dIsnm5vx9Dlxx/rRjFyO7uMBfKjEN6RX7oAenwfetHY=",
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "rev": "e6a7664a79ed4ec8a19d76fb60731190b8763874",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,130 @@
+{
+  description = "The PureScript Native Go Compiler Backend";
+
+  inputs = {
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
+    flake-utils.url = "github:numtide/flake-utils";
+    haskellNix.url = "github:input-output-hk/haskell.nix";
+    nixpkgs.follows = "haskellNix/nixpkgs-unstable";
+  };
+
+  outputs = { self, flake-compat, flake-utils, haskellNix, nixpkgs }:
+    let
+      systems = with flake-utils.lib.system; [
+        x86_64-darwin
+        x86_64-linux
+      ];
+
+      overlay = final: prev: {
+        # This dummy package is required in building the project, but `hsc2hs` is actually provided by GHC.
+        hsc2hs = final.stdenv.mkDerivation {
+          name = "hsc2hs";
+          unpackPhase = "true";
+          installPhase = "mkdir -p $out";
+        };
+
+        purescript-native-go = final.haskell-nix.project' {
+          src = ./.;
+        };
+      };
+
+      perSystem = system:
+        let
+          # We use both vanilla/upstream nixpkgs (as pinned by haskell.nix), and the patched/overlayed version.
+          # This is so that we can pull more things from binary cache.
+
+          pkgs = import nixpkgs {
+            inherit system;
+          };
+
+          pkgs' = import nixpkgs {
+            inherit system;
+            inherit (haskellNix) config;
+            overlays = [ haskellNix.overlay overlay ];
+          };
+
+          # A few utility functions for adding short/convenience app and package names to the flake
+          # The only reason these are per-system is because they leverage nixpkgs' lib
+
+          shortStuff = idx: attrs:
+            let
+              mapped = pkgs.lib.mapAttrs' (k: v:
+                let
+                  parts = builtins.split ":exe:" k;
+                  len = builtins.length parts;
+                  pair = if len == 3
+                    then pkgs.lib.nameValuePair (builtins.elemAt parts idx) v
+                    else pkgs.lib.nameValuePair k null;
+                in pair
+              ) attrs;
+              filtered = pkgs.lib.filterAttrs (k: v: v != null) mapped;
+            in filtered;
+
+          shortApps = final: prev: shortStuff 2 prev;
+          shortPackages = final: prev: shortStuff 0 prev;
+
+          # Where the fun stuff begins...
+
+          flake = pkgs'.purescript-native-go.flake {
+            packages =
+              let included = [ "psgo" "purescript" ];
+              in ps: pkgs.lib.filterAttrs (k: v: builtins.elem k included) ps;
+          };
+
+          extendFlake = final: prev:
+            let
+              # `hlint` is pulled in from regular nixpkgs because building with haskell.nix is failing for me due to version conflicts with `ghc-lib-parser`.
+              # `spago` won't build on my machine (due to `system-fileio` test failures likely related to my use of ZFS), so I need to grab it from a binary cache.
+              # Other CLI tools were brought in from pkgs (vs pkgs', `tools {}`, or packages/components in the flake) for caching and/or simplicity.
+              # Using the derivations inside the flake would pin CLI tools to the currently specified Stack resolver.
+
+              hackingShell = pkgs'.purescript-native-go.shellFor {
+                buildInputs = with pkgs; [
+                  bashInteractive
+                  cabal-install
+                  haskell-language-server
+                  hlint
+                  nixpkgs-fmt
+                  stack
+                ];
+                exactDeps = true;
+                withHoogle = true;
+              };
+
+              usingShell = pkgs'.purescript-native-go.shellFor {
+                buildInputs = (with pkgs; [
+                  bashInteractive
+                  delve
+                  go
+                  go-tools
+                  gopkgs
+                  spago
+                ]) ++ (with final.packages; [
+                  psgo
+                  purescript
+                ]);
+                exactDeps = true;
+                withHoogle = false;
+              };
+
+            in {
+              apps = pkgs.lib.fix (pkgs.lib.extends shortApps (pkgs.lib.const prev.apps));
+              defaultApp = final.apps.psgo;
+
+              packages = pkgs.lib.fix (pkgs.lib.extends shortPackages (pkgs.lib.const prev.packages));
+              defaultPackage = final.packages.psgo;
+
+              devShell = final.devShells.hacking-on-psgo;
+              devShells = {
+                hacking-on-psgo = hackingShell;
+                using-psgo = usingShell;
+              };
+            };
+        in
+          pkgs.lib.fix (pkgs.lib.extends extendFlake (pkgs.lib.const flake));
+
+    in { inherit overlay; } // flake-utils.lib.eachSystem systems perSystem;
+}

--- a/package.yaml
+++ b/package.yaml
@@ -22,25 +22,25 @@ extra-source-files:
 description:         Please see the README on Github at <https://github.com/andyarvanitis/purescript-native#readme>
 
 dependencies:
-- base >= 4.7 && < 5
-- bytestring >= 0.10.8.2 && < 0.11
-- purescript -any
+- base >=4.7 && <5
+- bytestring >=0.10.8.2 && <0.11
+- purescript >=0.13.0 && <0.14.0
 - base-compat >=0.6.0
 - protolude >=0.1.6
 - text
 - containers
 - filepath
-- monad-parallel >= 0.7.2.2 && <0.8
+- monad-parallel >=0.7.2.2 && <0.8
 - pattern-arrows >=0.0.2 && <0.1
 - safe >=0.3.9 && <0.4
 - transformers >=0.3.0 && <0.6
 - mtl >=2.1.0 && <2.3.0
 - aeson >=1.0 && <1.5
-- directory -any
-- process -any
-- file-embed -any
-- filemanip -any
-- gitrev -any
+- directory
+- process
+- file-embed
+- filemanip
+- gitrev
 
 library:
   source-dirs: src

--- a/psgo.cabal
+++ b/psgo.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.2.
+-- This file has been generated from package.yaml by hpack version 0.34.5.
 --
 -- see: https://github.com/sol/hpack
 
@@ -43,7 +43,24 @@ library
       Paths_psgo
   hs-source-dirs:
       src
-  default-extensions: ConstraintKinds DataKinds DeriveFunctor EmptyDataDecls FlexibleContexts KindSignatures LambdaCase MultiParamTypeClasses NoImplicitPrelude PatternGuards PatternSynonyms RankNTypes RecordWildCards OverloadedStrings ScopedTypeVariables TupleSections ViewPatterns
+  default-extensions:
+      ConstraintKinds
+      DataKinds
+      DeriveFunctor
+      EmptyDataDecls
+      FlexibleContexts
+      KindSignatures
+      LambdaCase
+      MultiParamTypeClasses
+      NoImplicitPrelude
+      PatternGuards
+      PatternSynonyms
+      RankNTypes
+      RecordWildCards
+      OverloadedStrings
+      ScopedTypeVariables
+      TupleSections
+      ViewPatterns
   build-depends:
       aeson >=1.0 && <1.5
     , base >=4.7 && <5
@@ -60,7 +77,7 @@ library
     , pattern-arrows >=0.0.2 && <0.1
     , process
     , protolude >=0.1.6
-    , purescript
+    , purescript >=0.13.0 && <0.14.0
     , safe >=0.3.9 && <0.4
     , text
     , transformers >=0.3.0 && <0.6
@@ -90,7 +107,7 @@ executable psgo
     , process
     , protolude >=0.1.6
     , psgo
-    , purescript
+    , purescript >=0.13.0 && <0.14.0
     , safe >=0.3.9 && <0.4
     , text
     , transformers >=0.3.0 && <0.6
@@ -121,7 +138,7 @@ test-suite psgo-test
     , process
     , protolude >=0.1.6
     , psgo
-    , purescript
+    , purescript >=0.13.0 && <0.14.0
     , safe >=0.3.9 && <0.4
     , text
     , transformers >=0.3.0 && <0.6

--- a/shell.nix
+++ b/shell.nix
@@ -9,4 +9,4 @@
   ) {
     src = ./.;
   }
-).defaultNix
+).shellNix

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,6 +6,7 @@ packages:
 extra-deps:
 - git: https://github.com/purescript/purescript
   commit: 9cad73ed8ea7df3011032ddbd2f3de5a0c08629c
+  # nix-sha256: 0mlgww6j8nfdgy6x7l6z5in37r6qs11wnxf1cpgqaiyabadaik20
 - happy-1.19.9
 - language-javascript-0.7.0.0
 - network-3.0.1.1


### PR DESCRIPTION
This adds Nix flake support, and replaces the default non-Stack Nix build (`default.nix`) with one that produces the default package from the flake.

I've created [a public binary cache on Cachix](https://app.cachix.org/cache/tangential#pull) that I've pushed the flake's associated derivations to.
For now, this only has `x86_64-linux` derivations, as I don't presently have access to a mac build host.

To hack on `psgo` itself, you can run `nix develop github:jjthiessen/purescript-native/add-flakes#hacking-on-psgo` (in this case, you'll have it checked out anyway, so you can use relative file system path references instead).
To use `psgo` in a project, you can run `nix develop github:jjthiessen/purescript-native/add-flakes#using-psgo` (or reference it with a relative path if you're trying to use a non-released version).

I think that the two bundled development shells should be generally useful, but I'd be interested to know what people think should or shouldn't be included.

Apart from the shells, the flake provides both `psgo` and `purescript`/`purs` as packages/apps.
Both `psgo` and `purescript` are included as I figured it could be important to use the same version of PureScript with `psgo` as the one that it was compiled against (and this ensures that it's the same commit).

You can directly execute binaries by doing something like `nix run github:jjthiessen/purescript-native/add-flakes#psgo`.

This still isn't perfect.
I'd like to figure out whether I can reduce the closure size at all, and it'd be nice if the Nix-enabled Stack build (`stack --nix build`) could use the same derivations as the flake/haskell.nix's `stackProject` (I'm not sure if this can be done).