### PR TITLE
Add identifier

### DIFF
--- a/src/CodeGen/IL/Common.hs
+++ b/src/CodeGen/IL/Common.hs
@@ -57,6 +57,7 @@ properToIL name
 -- ordinal value.
 identCharToText :: Char -> Text
 identCharToText 'ṩ' = "_ṩ"
+identCharToText '$' = "_ṩ"
 identCharToText c | isAlphaNum c = T.singleton c
 identCharToText '_' = "_"
 identCharToText '\'' = "ꞌ" -- lowercase saltillo


### PR DESCRIPTION
spago init -> set psgo backend -> spago build failed with error message about $ char code. added it in. maybe some sort of locale issue? i'm in LA area using Ubuntu 20.04 in wsl of windows.