### PR TITLE
update package.yaml for new stack

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -24,7 +24,7 @@ description:         Please see the README on Github at <https://github.com/andy
 dependencies:
 - base >= 4.7 && < 5
 - bytestring >= 0.10.8.2 && < 0.11
-- purescript -any
+- purescript
 - base-compat >=0.6.0
 - protolude >=0.1.6
 - text
@@ -36,11 +36,11 @@ dependencies:
 - transformers >=0.3.0 && <0.6
 - mtl >=2.1.0 && <2.3.0
 - aeson >=1.0 && <1.5
-- directory -any
-- process -any
-- file-embed -any
-- filemanip -any
-- gitrev -any
+- directory
+- process
+- file-embed
+- filemanip
+- gitrev
 
 library:
   source-dirs: src

--- a/psgo.cabal
+++ b/psgo.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.2.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -43,7 +43,24 @@ library
       Paths_psgo
   hs-source-dirs:
       src
-  default-extensions: ConstraintKinds DataKinds DeriveFunctor EmptyDataDecls FlexibleContexts KindSignatures LambdaCase MultiParamTypeClasses NoImplicitPrelude PatternGuards PatternSynonyms RankNTypes RecordWildCards OverloadedStrings ScopedTypeVariables TupleSections ViewPatterns
+  default-extensions:
+      ConstraintKinds
+      DataKinds
+      DeriveFunctor
+      EmptyDataDecls
+      FlexibleContexts
+      KindSignatures
+      LambdaCase
+      MultiParamTypeClasses
+      NoImplicitPrelude
+      PatternGuards
+      PatternSynonyms
+      RankNTypes
+      RecordWildCards
+      OverloadedStrings
+      ScopedTypeVariables
+      TupleSections
+      ViewPatterns
   build-depends:
       aeson >=1.0 && <1.5
     , base >=4.7 && <5


### PR DESCRIPTION
This removes the `-any` syntax from package.yaml, since compiling with stack 2.9.1 fails with a parse error.